### PR TITLE
Fix closing brace in Usuario entity

### DIFF
--- a/DentAssist.Web/Models/Entities/Usuario.cs
+++ b/DentAssist.Web/Models/Entities/Usuario.cs
@@ -14,4 +14,4 @@
         // Podríamos tener una propiedad similar para Recepcionista si tuviéramos una entidad Recepcionista,
         // pero por simplicidad, si la recepcionista solo usa el sistema, el rol es suficiente.
     }
-};
+}


### PR DESCRIPTION
## Summary
- fix stray semicolon after namespace closing brace in `Usuario` entity

## Testing
- `dotnet build DentAssist.Web/DentAssist.Web.csproj -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b5b31b57c832d9a90e03b42307efa